### PR TITLE
Feat: extend meta type in RipeAuth

### DIFF
--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -11,6 +11,7 @@ export type RipeAccount = {
     avatar_url?: string;
     twitter_username?: string;
     meta?: {
+        brand_t?: string | string[];
         phone_number?: string;
         linkedin_username?: string;
         name?: string;
@@ -21,6 +22,7 @@ export type RipeAccount = {
         birth_date?: string;
         position?: string;
         nationality?: string;
+        [x: string]: unknown;
     };
     last_login?: number;
     roles?: number[];


### PR DESCRIPTION
Extend the `meta` field type with a possible `brand_t`. Allow any other json key/value pairs for meta as it is mainly unstructured data so as to avoid future crashes. Ideally all fields should be typed tho.