### PR TITLE
Feat: extract middleware for re-use in RIPE Twitch

### DIFF
--- a/js/fastify/plugins/acl.js
+++ b/js/fastify/plugins/acl.js
@@ -2,21 +2,23 @@ import fp from "fastify-plugin";
 
 import { getRipeAuth } from "../../auth";
 
-const acl = async (app, options) => {
-    app.addHook("onRequest", (req, res, next) => {
-        req.getAcl = async ctx => {
-            req.ripeCtx = req.ripeCtx === undefined ? {} : req.ripeCtx;
-            if (options.skipAuth) {
-                req.ripeCtx.user = options.skipUser || "anonymous";
-                return options.skipAcl || ["*"];
-            }
-            const auth = await getRipeAuth(req);
-            req.ripeCtx.user = auth.account.username;
-            return auth.acl.acl;
-        };
-
-        next();
-    });
+const aclPlugin = async (app, options) => {
+    app.addHook("onRequest", acl);
 };
 
-export const ripeAcl = fp(acl);
+const acl = (req, res, next) => {
+    req.getAcl = async ctx => {
+        req.ripeCtx = req.ripeCtx === undefined ? {} : req.ripeCtx;
+        if (options.skipAuth) {
+            req.ripeCtx.user = options.skipUser || "anonymous";
+            return options.skipAcl || ["*"];
+        }
+        const auth = await getRipeAuth(req);
+        req.ripeCtx.user = auth.account.username;
+        return auth.acl.acl;
+    };
+
+    next();
+};
+
+export const ripeAcl = fp(aclPlugin);

--- a/js/fastify/plugins/acl.js
+++ b/js/fastify/plugins/acl.js
@@ -2,11 +2,7 @@ import fp from "fastify-plugin";
 
 import { getRipeAuth } from "../../auth";
 
-const aclPlugin = async (app, options) => {
-    app.addHook("onRequest", acl);
-};
-
-const acl = (req, res, next) => {
+export const acl = (options = {}) => (req, res, next) => {
     req.getAcl = async ctx => {
         req.ripeCtx = req.ripeCtx === undefined ? {} : req.ripeCtx;
         if (options.skipAuth) {
@@ -19,6 +15,10 @@ const acl = (req, res, next) => {
     };
 
     next();
+};
+
+const aclPlugin = async (app, options) => {
+    app.addHook("onRequest", acl(options));
 };
 
 export const ripeAcl = fp(aclPlugin);

--- a/types/fastify/plugins/acl.d.ts
+++ b/types/fastify/plugins/acl.d.ts
@@ -4,7 +4,8 @@ import {
     RawRequestDefaultExpression,
     RawServerBase,
     RawServerDefault,
-    RawReplyDefaultExpression
+    RawReplyDefaultExpression,
+    FastifyRequest
 } from "fastify";
 
 type Options = FastifyPluginOptions & {
@@ -12,6 +13,14 @@ type Options = FastifyPluginOptions & {
     skipUser?: string;
     skipAcl?: string[];
 };
+
+export declare function acl(
+    options?: Options
+): (
+    req: FastifyRequest,
+    res: FastifyReply,
+    next: HookHandlerDoneFunction
+) => preValidationHookHandler | void;
 
 export declare function ripeAcl<Server extends RawServerBase = RawServerDefault>(
     instance: FastifyInstance<

--- a/types/fastify/plugins/acl.d.ts
+++ b/types/fastify/plugins/acl.d.ts
@@ -5,7 +5,10 @@ import {
     RawServerBase,
     RawServerDefault,
     RawReplyDefaultExpression,
-    FastifyRequest
+    FastifyRequest,
+    FastifyReply,
+    HookHandlerDoneFunction,
+    preValidationHookHandler
 } from "fastify";
 
 type Options = FastifyPluginOptions & {


### PR DESCRIPTION
The RIPE ACL middleware will be used in RIPE Twitch as a function of (req, res, next) => ...
This PR splits existing code into the ACL middleware and the ACL fastify plugin (ripeAcl) without introducing breaking changes.