### PR TITLE
fix: change operator to $and if only a keyword is given as filter

### DIFF
--- a/js/filter.js
+++ b/js/filter.js
@@ -86,6 +86,10 @@ export const filterToParams = (
         }
         operator = "$and";
     } else {
+        // change the operator to '$and' if a keyword
+        // was provided, since a keyword can be composed
+        // of two filters
+        if (KEYWORDS[filterS]) operator = "$and";
         filters.push(
             ...Object.entries(filterFields).flatMap(([field, operator]) =>
                 _buildFilter(field, operator, filterS, keywordFields)

--- a/js/filter.js
+++ b/js/filter.js
@@ -86,10 +86,13 @@ export const filterToParams = (
         }
         operator = "$and";
     } else {
-        // change the operator to '$and' if a keyword
-        // was provided, since a keyword can be composed
-        // of two filters
+        // changes the operator to '$and' if a keyword was provided,
+        // since a keyword can be composed of two or more filters
         if (KEYWORDS[filterS]) operator = "$and";
+
+        // adds the multiple filters that will apply the filter string
+        // to the multiple default targeting fields, effectively trying
+        // to mach any of them (fuzzy string searching)
         filters.push(
             ...Object.entries(filterFields).flatMap(([field, operator]) =>
                 _buildFilter(field, operator, filterS, keywordFields)


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/165#issuecomment-862303810  |
| Dependencies | -- |
| Decisions | Change operator to `$and` when in the presence of a keyword in `incomplete` format (no field provided). This is necessary since keywords can be composed of more than one filter. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/25725586/122241674-a73d8d80-ceba-11eb-8cf0-9e330b70ffe0.png) |
