### PR TITLE
feat: improve encodeBarcode128B and warn about its limitations

### DIFF
--- a/js/barcode.js
+++ b/js/barcode.js
@@ -1,7 +1,12 @@
+const shiftChars = ["Ã", "Ä", "Å", "Æ", "Ç", "È", "É", "Ê"];
+
 /**
  * Encodes the given value following the Code 128 Set B
  * guidelines, so that the value can be shown using the
  * barcode 128 font.
+ *
+ * This function contains limitations when more than 3
+ * consecutive numbers are present in the value.
  *
  * @param {String} value The string value to be encoded.
  * @returns {String} The Code 128 Set B value to be used with the
@@ -15,6 +20,7 @@ export const encodeBarcode128B = value => {
     // within the data
     const length = value.length;
     let checksumValue = 104;
+
     for (let i = 0; i < length; i++) {
         const encodedChar = value.charCodeAt(i) - 32;
         checksumValue += (i + 1) * encodedChar;
@@ -22,12 +28,15 @@ export const encodeBarcode128B = value => {
 
     // the checksum value is finally calculated by
     // doing the remainder of the total by 103
-    // (Modulus 103 Checksum)
-    const checksum = checksumValue % 103;
+    // (Modulus 103 Checksum) and replacing shift
+    // characters code with the respective characters
+    const checksumInt = parseInt(checksumValue % 103, 10);
+    const checksum =
+        checksumInt > 94 ? shiftChars[checksumInt - 95] : String.fromCharCode(checksumInt + 32);
 
     // builds the encoded barcode value by adding the
     // START and STOP code, the value and the checksum
     const startCodeB = "Ì";
     const stopCodeB = "Î";
-    return `${startCodeB}${value}${String.fromCharCode(checksum + 32)}${stopCodeB}`;
+    return `${startCodeB}${value}${checksum}${stopCodeB}`;
 };

--- a/js/barcode.js
+++ b/js/barcode.js
@@ -1,4 +1,8 @@
-const shiftChars = ["Ã", "Ä", "Å", "Æ", "Ç", "È", "É", "Ê"];
+/**
+ * The characters that are going to be used as the shift
+ * ones in the encoding operation.
+ */
+const SHIFT_CHARS = ["Ã", "Ä", "Å", "Æ", "Ç", "È", "É", "Ê"];
 
 /**
  * Encodes the given value following the Code 128 Set B
@@ -32,7 +36,7 @@ export const encodeBarcode128B = value => {
     // characters code with the respective characters
     const checksumInt = parseInt(checksumValue % 103, 10);
     const checksum =
-        checksumInt > 94 ? shiftChars[checksumInt - 95] : String.fromCharCode(checksumInt + 32);
+        checksumInt > 94 ? SHIFT_CHARS[checksumInt - 95] : String.fromCharCode(checksumInt + 32);
 
     // builds the encoded barcode value by adding the
     // START and STOP code, the value and the checksum


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/custom-reports/issues/138 |
| Dependencies | -- |
| Decisions | The current barcode128 encoding function contains limitations, more specifically when the value to be encoded contains more than 3 consecutive digits. Will investigate how to port the logic in https://github.com/graphicore/librebarcode/blob/master/app/lib/code128Encoder/encoder.mjs here. <br> Added an enhancement for shiftChars and a warning in the function docs to the limitations in the function. |
| Animated GIF | -- |
