### PR TITLE
Feat: Number to N digits text

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -87,3 +87,18 @@ export const parseSearchParams = query => {
 
     return options;
 };
+
+/**
+ * Turns a number into a string with a given
+ * length using a given filler character.
+ *
+ * @param {Number} number The number to be turned into text.
+ * @param {Number} length The desired length of the resulting text.
+ * @param {String} filler The character to use as filling.
+ * @returns {String} The number in text format with desired length.
+ */
+export const nDigitsText = (number, length = 2, filler = "0") => {
+    const text = number.toString();
+    if (text.length >= length) return text.slice(0, length);
+    return filler.repeat(length - text.length) + text;
+};

--- a/test/util.js
+++ b/test/util.js
@@ -47,3 +47,37 @@ describe("parseSearchParams()", function() {
         assert.deepStrictEqual(result, { hello: "hello world", hello2: "hello world2" });
     });
 });
+
+describe("nDigitsText()", function() {
+    it("should be able to add filler characters to small numbers", () => {
+        let result = ripeCommons.nDigitsText(9);
+        assert.deepStrictEqual(result, "09");
+
+        result = ripeCommons.nDigitsText(5, 3);
+        assert.deepStrictEqual(result, "005");
+    });
+
+    it("should do nothing to big enough numbers", () => {
+        let result = ripeCommons.nDigitsText(50);
+        assert.deepStrictEqual(result, "50");
+
+        result = ripeCommons.nDigitsText(5000, 4);
+        assert.deepStrictEqual(result, "5000");
+    });
+
+    it("should cut huge numbers to the desired size", () => {
+        let result = ripeCommons.nDigitsText(10000000);
+        assert.deepStrictEqual(result, "10");
+
+        result = ripeCommons.nDigitsText(10000000, 4);
+        assert.deepStrictEqual(result, "1000");
+    });
+
+    it("should be able to use different filling characters", () => {
+        let result = ripeCommons.nDigitsText(5, 4);
+        assert.deepStrictEqual(result, "0005");
+
+        result = ripeCommons.nDigitsText(5, 4, "X");
+        assert.deepStrictEqual(result, "XXX5");
+    });
+});


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | When developing UIs (like for green) sometimes numbers displayed as text on the screen should have exactly N digits. In Green's example, we wanted a number ranging from [0..99] to have 2 digits only. This function is more generic for future use cases. |

