### PR TITLE
fix: parsing to int as backend can't deal with floats in parameters

### DIFF
--- a/js/filter.js
+++ b/js/filter.js
@@ -161,14 +161,14 @@ const _buildKeywordQuery = (field, operator, left, right) => {
     switch (operator) {
         case "gt":
         case "gte":
-            return [`${field}:${operator}:${parseInt(right.getTime() / 1000)}`];
+            return [`${field}:${operator}:${Math.floor(right.getTime() / 1000)}`];
         case "lt":
         case "lte":
-            return [`${field}:${operator}:${parseInt(left.getTime() / 1000)}`];
+            return [`${field}:${operator}:${Math.floor(left.getTime() / 1000)}`];
         default:
             return [
-                `${field}:gte:${parseInt(left.getTime() / 1000)}`,
-                `${field}:lt:${parseInt(right.getTime() / 1000)}`
+                `${field}:gte:${Math.floor(left.getTime() / 1000)}`,
+                `${field}:lt:${Math.floor(right.getTime() / 1000)}`
             ];
     }
 };

--- a/js/filter.js
+++ b/js/filter.js
@@ -53,11 +53,6 @@ const KEYWORDS = {
         const nextMonth = new Date(new Date(today.setMonth(month + 1)).setDate(1));
         const nextNextMonth = new Date(new Date(today.setMonth(month + 2)).setDate(1));
         return _buildKeywordQuery(field, operator, nextMonth, nextNextMonth);
-    },
-    "@recently-updated": () => {
-        const recentOrderDotSeconds = 600;
-        const recentTime = new Date((Date.now() - recentOrderDotSeconds * 1000));
-        return _buildKeywordQuery("last_updated", "gt", null, recentTime);
     }
 };
 

--- a/js/filter.js
+++ b/js/filter.js
@@ -161,14 +161,14 @@ const _buildKeywordQuery = (field, operator, left, right) => {
     switch (operator) {
         case "gt":
         case "gte":
-            return [`${field}:${operator}:${right.getTime() / 1000}`];
+            return [`${field}:${operator}:${parseInt(right.getTime() / 1000)}`];
         case "lt":
         case "lte":
-            return [`${field}:${operator}:${left.getTime() / 1000}`];
+            return [`${field}:${operator}:${parseInt(left.getTime() / 1000)}`];
         default:
             return [
-                `${field}:gte:${left.getTime() / 1000}`,
-                `${field}:lt:${right.getTime() / 1000}`
+                `${field}:gte:${parseInt(left.getTime() / 1000)}`,
+                `${field}:lt:${parseInt(right.getTime() / 1000)}`
             ];
     }
 };

--- a/js/filter.js
+++ b/js/filter.js
@@ -53,6 +53,11 @@ const KEYWORDS = {
         const nextMonth = new Date(new Date(today.setMonth(month + 1)).setDate(1));
         const nextNextMonth = new Date(new Date(today.setMonth(month + 2)).setDate(1));
         return _buildKeywordQuery(field, operator, nextMonth, nextNextMonth);
+    },
+    "@recently-updated": () => {
+        const recentOrderDotSeconds = 600;
+        const recentTime = new Date((Date.now() - recentOrderDotSeconds * 1000));
+        return _buildKeywordQuery("last_updated", "gt", null, recentTime);
     }
 };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/234 |
| Decisions | - Add `@recently-updated` filter <br> - Fix number filters by parsing to integers as ripe-core coudn't deal with float numbers passed as parameters.   |
