### PR TITLE
feat: mime type util function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added `mimeType` util function that returns the correct mime type of a given file format
 
 ### Changed
 

--- a/js/util.js
+++ b/js/util.js
@@ -101,11 +101,11 @@ export const parseSearchParams = query => {
 
 /**
  * Returns the correct mime type to a given file format.
- * 
- * @param {String} format The format identifier of a file. 
+ *
+ * @param {String} format The format identifier of a file.
  * @returns The mime type for the given format.
  */
-export const mimeType = (format) => {
+export const mimeType = format => {
     switch (format) {
         case "html":
             return "text/html";

--- a/js/util.js
+++ b/js/util.js
@@ -98,3 +98,22 @@ export const parseSearchParams = query => {
 
     return options;
 };
+
+/**
+ * Returns the correct mime type to a given file format.
+ * 
+ * @param {String} format The format identifier of a file. 
+ * @returns The mime type for the given format.
+ */
+export const mimeType = (format) => {
+    switch (format) {
+        case "html":
+            return "text/html";
+        case "pdf":
+            return "application/pdf";
+        case "png":
+            return "image/png";
+        default:
+            return format;
+    }
+};

--- a/test/util.js
+++ b/test/util.js
@@ -47,3 +47,25 @@ describe("parseSearchParams()", function() {
         assert.deepStrictEqual(result, { hello: "hello world", hello2: "hello world2" });
     });
 });
+
+describe("mimeType()", function() {
+    it("should return the default mime type", async () => {
+        const mime = await ripeCommons.mimeType("gif");
+        assert.strictEqual(mime, "gif");
+    });
+
+    it("should return the HTML mime type", async () => {
+        const mime = await ripeCommons.mimeType("html");
+        assert.strictEqual(mime, "text/html");
+    });
+
+    it("should return the PDF mime type", async () => {
+        const mime = await ripeCommons.mimeType("pdf");
+        assert.strictEqual(mime, "application/pdf");
+    });
+
+    it("should return the PNG mime type", async () => {
+        const mime = await ripeCommons.mimeType("png");
+        assert.strictEqual(mime, "image/png");
+    });
+});


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/peri-invoicing/pull/6 |
| Dependencies | -- |
| Decisions | -  Added `mimeType` util function that returns the correct mime type of a given file format|
| Animated GIF | -- |
