### PR TITLE
fix: exact length limit break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* `breakString` bug where an additional empty line was returned if the string **exactly** fit the last line
 
 ## [0.8.0] - 2021-10-13
 

--- a/js/string.js
+++ b/js/string.js
@@ -49,10 +49,12 @@ const _breakStringByParagraph = value => {
  * using a work keeping strategy.
  * @param {Number} maxLength The maximum length (as number of characters)
  * allowed per line split.
+ * @param {Boolean} trim If the lines should be right and left trimmed to
+ * avoid extra unwanted space characters.
  * @returns {Array} The complete set of lines splitted using a per word
  * strategy.
  */
-const _breakStringByWord = (value, maxLength = 80) => {
+const _breakStringByWord = (value, maxLength = 80, trim = true) => {
     const lines = [];
     let line = "";
 
@@ -61,7 +63,7 @@ const _breakStringByWord = (value, maxLength = 80) => {
     // to be able to allocate them over the multiple lines
     value.split(" ").forEach(word => {
         if ((line + word).length > maxLength) {
-            line = line.trim();
+            if (trim) line = line.trim();
             lines.push(line);
             line = word;
         } else {
@@ -74,7 +76,7 @@ const _breakStringByWord = (value, maxLength = 80) => {
 
     // trims the last line an in case the line is valid
     // adds it to the complete set of lines
-    line = line.trim();
+    if (trim) line = line.trim();
     if (line.length > 0) lines.push(line);
 
     // returns the final sequence of lines with the complete

--- a/js/string.js
+++ b/js/string.js
@@ -72,8 +72,8 @@ const _breakStringByWord = (value, maxLength = 80) => {
             line = "";
         }
     });
-    line = line[line.length - 1] === " " ? line.slice(0, -1) : line;
-    lines.push(line);
+    line = line.trim();
+    if (line.length > 0) lines.push(line);
     return lines;
 };
 

--- a/js/string.js
+++ b/js/string.js
@@ -55,25 +55,30 @@ const _breakStringByParagraph = value => {
 const _breakStringByWord = (value, maxLength = 80) => {
     const lines = [];
     let line = "";
+
+    // splits the provided value around the space character
+    // allowing proper iteration over the sequence of words
+    // to be able to allocate them over the multiple lines
     value.split(" ").forEach(word => {
         if ((line + word).length > maxLength) {
-            line = line[line.length - 1] === " " ? line.slice(0, -1) : line;
+            line = line.trim();
             lines.push(line);
             line = word;
         } else {
             line += word;
         }
 
+        line = line.trimStart();
         line += " ";
-
-        if (line.length > maxLength) {
-            line = line.slice(0, -1);
-            lines.push(line);
-            line = "";
-        }
     });
+
+    // trims the last line an in case the line is valid
+    // adds it to the complete set of lines
     line = line.trim();
     if (line.length > 0) lines.push(line);
+
+    // returns the final sequence of lines with the complete
+    // set of words properly splitted
     return lines;
 };
 

--- a/test/string.js
+++ b/test/string.js
@@ -50,14 +50,14 @@ describe("String", function() {
 
         it("should trim the beginning and end of lines", () => {
             const lines = ripeCommons.breakString(
-                "   A very long address line that is     going to be broken preferably word by word   ",
+                "   A very long address line that is     going to be broken preferably word by    word   ",
                 35,
                 3
             );
             assert.deepStrictEqual(lines, [
                 "A very long address line that is",
                 "going to be broken preferably word",
-                "by word"
+                "by    word"
             ]);
         });
 

--- a/test/string.js
+++ b/test/string.js
@@ -8,6 +8,11 @@ describe("String", function() {
             assert.deepStrictEqual(lines, ["Small Address Line"]);
         });
 
+        it("should not break if it exactly fits in a single line", () => {
+            const lines = ripeCommons.breakString("Exactly the limit of characters", 31, 2);
+            assert.deepStrictEqual(lines, ["Exactly the limit of characters"]);
+        });
+
         it("should break by new lines when present", () => {
             const lines = ripeCommons.breakString(
                 "Address Line1\nAddress Line2\nAddress Line3",

--- a/test/string.js
+++ b/test/string.js
@@ -48,6 +48,19 @@ describe("String", function() {
             ]);
         });
 
+        it("should trim the beginning and end of lines", () => {
+            const lines = ripeCommons.breakString(
+                "   A very long address line that is     going to be broken preferably word by word   ",
+                35,
+                3
+            );
+            assert.deepStrictEqual(lines, [
+                "A very long address line that is",
+                "going to be broken preferably word",
+                "by word"
+            ]);
+        });
+
         it("should fail to break the address line since it does not fit in three lines", () => {
             assert.throws(
                 () =>

--- a/test/string.js
+++ b/test/string.js
@@ -44,7 +44,7 @@ describe("String", function() {
         });
 
         it("should fail to break the address line since it does not fit in three lines", () => {
-            assert.rejects(
+            assert.throws(
                 () =>
                     ripeCommons.breakString(
                         "A very long address line that does not fit in the string limit of three lines each with thirty five characters",
@@ -53,7 +53,7 @@ describe("String", function() {
                     ),
                 err => {
                     assert.strictEqual(err.name, "Error");
-                    assert.strictEqual(err.message, "Address is too long");
+                    assert.strictEqual(err.message, "Value is too long");
                     return true;
                 }
             );


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | .. |
| Dependencies | -- |
| Decisions | If the string to break fits exactly the line limit, it would produce an additional empty line. Wrote the test to catch it first, then fixed it. Fixed an additional test that was not correctly asserting. |

