### PR TITLE
Add object to CSV methods, other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Refactored the ACL function out of the fastify module to be used by express as well - [ripe-orchestra/#16](https://github.com/ripe-tech/ripe-orchestra/issues/16)
+* Refactored the CSV methods to allow for conversion of objects and list of objects to CSV - [ripe-pulse/#302](https://github.com/ripe-tech/ripe-pulse/issues/302)
 
 ### Fixed
 

--- a/test/csv.js
+++ b/test/csv.js
@@ -2,6 +2,127 @@ const assert = require("assert");
 const ripeCommons = require("..");
 
 describe("CSV", () => {
+    describe("#objectListToCsv", () => {
+        it("should handle objects list with headers", () => {
+            const headers = ["name", "title"];
+            const input = [
+                { name: "João Magalhães", title: "mr" },
+                { name: "Gabriel Candal", title: "mr" }
+            ];
+            const result = ripeCommons.objectListToCsv(input, headers);
+            assert.deepStrictEqual(result, "name,title\nJoão Magalhães,mr\nGabriel Candal,mr");
+        });
+
+        it("should handle objects list without headers", () => {
+            const input = [
+                { name: "João Magalhães", title: "mr" },
+                { name: "Gabriel Candal", title: "mr" }
+            ];
+            const result = ripeCommons.objectListToCsv(input);
+            assert.deepStrictEqual(result, "João Magalhães,mr\nGabriel Candal,mr");
+        });
+
+        it("should handle list objects with commas", () => {
+            const input = [
+                { name: "Magalhães, João", title: "mr" },
+                { name: "Gabriel Candal", title: "mr" }
+            ];
+            const result = ripeCommons.objectListToCsv(input);
+            assert.deepStrictEqual(result, '"Magalhães, João",mr\nGabriel Candal,mr');
+        });
+    });
+
+    describe("#objectToCsv", () => {
+        it("should handle objects with commas", () => {
+            const input = { name: "João, Magalhães", title: "mr" };
+            const result = ripeCommons.objectToCsv(input);
+            assert.deepStrictEqual(result, '"João, Magalhães",mr');
+        });
+
+        it("should handle objects with headers", () => {
+            const headers = ["name", "title"];
+            const input = { name: "João Magalhães", title: "mr" };
+            const result = ripeCommons.objectToCsv(input, headers);
+            assert.deepStrictEqual(result, "João Magalhães,mr");
+        });
+
+        it("should handle objects with headers to filter", () => {
+            const headers = ["name", "title"];
+            const input = { name: "João Magalhães", title: "mr", role: "CTO" };
+            const result = ripeCommons.objectToCsv(input, headers);
+            assert.deepStrictEqual(result, "João Magalhães,mr");
+        });
+
+        it("should handle objects with null / undefined values", () => {
+            const headers = ["age", "name", "title", "field"];
+            const input = { age: undefined, name: "João Magalhães", title: undefined, field: "Software Dev" };
+            const result = ripeCommons.objectToCsv(input, headers);
+            assert.deepStrictEqual(result, ",João Magalhães,,Software Dev");
+        });
+
+        it("should handle objects with numbers", () => {
+            const headers = ["name", "number"];
+            const input = { name: "João Magalhães", number: 1 };
+            const result = ripeCommons.objectToCsv(input, headers);
+            assert.deepStrictEqual(result, "João Magalhães,1");
+        });
+
+        it("should handle custom delimiters", () => {
+            const headers = ["name", "title"];
+            const input = { name: "João Magalhães", title: "mr" };
+            const result = ripeCommons.objectToCsv(input, headers, ";");
+            assert.deepStrictEqual(result, "João Magalhães;mr");
+        });
+    });
+
+    describe("#arrayListToCsv", () => {
+        it("should handle string arrays", () => {
+            const headers = ["name", "title"];
+            const input = [
+                ["João Magalhães", "mr"],
+                ["Gabriel Candal", "mr"]
+            ];
+            const result = ripeCommons.arrayListToCsv(input, headers);
+            assert.deepStrictEqual(result, "name,title\nJoão Magalhães,mr\nGabriel Candal,mr");
+        });
+
+        it("should handle nested array of strings", () => {
+            const input = [["a", ["b", ["c", "d"]]]];
+            const result = ripeCommons.arrayListToCsv(input);
+            assert.deepStrictEqual(result, 'a,"b,c,d"');
+        });
+
+        it("should handle array of strings without headers", () => {
+            const input = [
+                ["name", "title"],
+                ["João Magalhães", "mr"],
+                ["Gabriel Candal", "mr"]
+            ];
+            const result = ripeCommons.arrayListToCsv(input);
+            assert.deepStrictEqual(result, "name,title\nJoão Magalhães,mr\nGabriel Candal,mr");
+        });
+    });
+
+    describe("#arrayToCsv", () => {
+        it("should handle string array with commas", () => {
+            const input = ["Magalhães, João", "mr"];
+            const result = ripeCommons.arrayToCsv(input);
+            assert.deepStrictEqual(result, '"Magalhães, João",mr');
+        });
+
+        it("should handle string array with quotes", () => {
+            const input = ["João", 'Candal, "Gabriel"'];
+            const result = ripeCommons.arrayToCsv(input);
+            assert.deepStrictEqual(result, 'João,"Candal, "Gabriel""');
+        });
+
+        it("should handle string arrays with numbers", () => {
+            const input = [1, "Gabriel Candal"];
+            const result = ripeCommons.arrayToCsv(input);
+            assert.deepStrictEqual(result, "1,Gabriel Candal");
+        });
+    });
+
     describe("#parseCsv", () => {
         it("should allow simple CSV parsing", () => {
             const result = ripeCommons.parseCsv(


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to [ripe-pulse/#302](https://github.com/ripe-tech/ripe-pulse/issues/302) |
| Dependencies | https://github.com/ripe-tech/ripe-commons-js/pull/33 |
| Decisions | There was no way to convert an object to CSV, and the previous structure was rather inflexible in how it could be used. This improved flexibility, reliability with a new way to convert to string any value, while giving the new adding the capability to covert objects and lists of objects to a CSV format, with possibly custom delimiters. |
