### PR TITLE
#298 Reverse date string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `getRipeWhiteAdminOptions` method - [ripe-util-vue/#267](https://github.com/ripe-tech/ripe-util-vue/issues/267)
 * Add `getRipeWhiteOptions` method - [ripe-util-vue/#267](https://github.com/ripe-tech/ripe-util-vue/issues/267)
 * Add testing to env methods
+* Add option to reverse the `dateString` - [ripe-util-vue](https://github.com/ripe-tech/ripe-util-vue/issues/259)
 
 ### Changed
 

--- a/js/time.js
+++ b/js/time.js
@@ -1,10 +1,10 @@
 export const dateString = (
     timestamp = null,
     separator = "/",
-    { year = true, month = true, day = true } = {}
+    { year = true, month = true, day = true, reverse = false } = {}
 ) => {
     timestamp = timestamp === null ? new Date() / 1000 : timestamp;
-    const buffer = [];
+    let buffer = [];
     const date = new Date(timestamp * 1000);
     const dayV = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
     let monthV = date.getMonth() + 1;
@@ -13,16 +13,17 @@ export const dateString = (
     if (day) buffer.push(dayV);
     if (month) buffer.push(monthV);
     if (year) buffer.push(yearV);
+    if (reverse) buffer = buffer.reverse();
     return buffer.join(separator);
 };
 
 export const dateStringUTC = (
     timestamp = null,
     separator = "/",
-    { year = true, month = true, day = true } = {}
+    { year = true, month = true, day = true, reverse = false } = {}
 ) => {
     timestamp = timestamp === null ? new Date() / 1000 : timestamp;
-    const buffer = [];
+    let buffer = [];
     const date = new Date(timestamp * 1000);
     const dayV = date.getUTCDate() < 10 ? `0${date.getUTCDate()}` : date.getUTCDate();
     let monthV = date.getUTCMonth() + 1;
@@ -31,6 +32,7 @@ export const dateStringUTC = (
     if (day) buffer.push(dayV);
     if (month) buffer.push(monthV);
     if (year) buffer.push(yearV);
+    if (reverse) buffer = buffer.reverse();
     return buffer.join(separator);
 };
 
@@ -73,9 +75,22 @@ export const dateTimeString = (
     separator = "_",
     dateSeparator = "/",
     timeSeparator = ":",
-    { year = true, month = true, day = true, hours = true, minutes = true, seconds = true } = {}
+    {
+        year = true,
+        month = true,
+        day = true,
+        reverse = false,
+        hours = true,
+        minutes = true,
+        seconds = true
+    } = {}
 ) => {
-    const dateS = dateString(timestamp, dateSeparator, { year: year, month: month, day: day });
+    const dateS = dateString(timestamp, dateSeparator, {
+        year: year,
+        month: month,
+        day: day,
+        reverse: reverse
+    });
     const timeS = timeString(timestamp, timeSeparator, {
         hours: hours,
         minutes: minutes,

--- a/test/time.js
+++ b/test/time.js
@@ -8,6 +8,13 @@ describe("Time", function() {
             assert.deepStrictEqual(result, "12/10/2020");
         });
 
+        it("should format simple date strings and reverse the output", () => {
+            const result = ripeCommons.dateString(new Date("10/12/2020") / 1000, "-", {
+                reverse: true
+            });
+            assert.deepStrictEqual(result, "2020-10-12");
+        });
+
         it("should format current date values", () => {
             const result = ripeCommons.dateString();
             assert.deepStrictEqual(typeof result, "string");
@@ -18,6 +25,13 @@ describe("Time", function() {
         it("should format simple date strings", () => {
             const result = ripeCommons.dateStringUTC(new Date("10/12/2020Z") / 1000);
             assert.deepStrictEqual(result, "12/10/2020");
+        });
+
+        it("should format simple date strings and reverse the output", () => {
+            const result = ripeCommons.dateStringUTC(new Date("10/12/2020") / 1000, "-", {
+                reverse: true
+            });
+            assert.deepStrictEqual(result, "2020-10-12");
         });
 
         it("should format current date values", () => {
@@ -54,6 +68,17 @@ describe("Time", function() {
         it("should format simple date time strings", () => {
             const result = ripeCommons.dateTimeString(new Date("10/12/2020") / 1000);
             assert.deepStrictEqual(result, "12/10/2020_00:00:00");
+        });
+
+        it("should format simple date time strings and reverse the date string", () => {
+            const result = ripeCommons.dateTimeString(
+                new Date("10/12/2020") / 1000,
+                " ",
+                "/",
+                ":",
+                { reverse: true }
+            );
+            assert.deepStrictEqual(result, "2020/10/12 00:00:00");
         });
 
         it("should format current date time values", () => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue |https://github.com/ripe-tech/ripe-util-vue/issues/259|
| Decisions |After the discussion in [here](https://github.com/ripe-tech/ripe-util-vue/pull/298#discussion_r891034073), it was deemed necessary to have a reverse date option, since that's what the `ripe-input` is expecting |
