### PR TITLE
#436: filter appliance based on value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* `removeFunc` to specify which fields to remove (not filter for) based on functions - [ripe-pulse/#436](https://github.com/ripe-tech/ripe-pulse/issues/436)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.13.0] - 2023-11-27
+
+### Added
+
 * `removeFunc` to specify which fields to remove (not filter for) based on functions - [ripe-pulse/#436](https://github.com/ripe-tech/ripe-pulse/issues/436)
 
 ### Changed
 
 * Remove Travis CI - [products/#97](https://github.com/ripe-tech/products/issues/97)
-
-### Fixed
-
-*
 
 ## [0.12.4] - 2022-12-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-commons",
-    "version": "0.12.4",
+    "version": "0.13.0",
     "description": "The RIPE Commons library",
     "keywords": [
         "commons",

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,8 +1,8 @@
 const assert = require("assert");
 const ripeCommons = require("..");
 
-describe("Filter", function() {
-    describe("#filterToParams()", function() {
+describe("Filter", function () {
+    describe("#filterToParams()", function () {
         it("should be able to build a filter string to filter only for id equal to 2", () => {
             const options = {
                 filter: "id=2",
@@ -546,6 +546,89 @@ describe("Filter", function() {
                 nameFunc,
                 filterFields,
                 keywordFields
+            );
+            assert.deepStrictEqual(result, {
+                number_records: 5,
+                start_record: 0
+            });
+        });
+
+        it("should not leave out filter fields when applicable to the searched value", () => {
+            const options = {
+                filter: "friends=13",
+                limit: 5,
+                start: 0
+            };
+            const filterFields = {
+                friends: "in"
+            };
+            const removeFunc = {
+                friends: value => isNaN(parseInt(value))
+            };
+            const result = ripeCommons.filterToParams(
+                options,
+                {},
+                {},
+                filterFields,
+                {},
+                {},
+                removeFunc
+            );
+            assert.deepStrictEqual(result, {
+                filter_operator: "$and",
+                "filters[]": ["friends:in:13"],
+                number_records: 5,
+                start_record: 0
+            });
+        });
+
+        it("should leave out filter fields not applicable to the searched value", () => {
+            const options = {
+                filter: "friends=john",
+                limit: 5,
+                start: 0
+            };
+            const filterFields = {
+                friends: "in"
+            };
+            const removeFunc = {
+                friends: value => isNaN(parseInt(value))
+            };
+            const result = ripeCommons.filterToParams(
+                options,
+                {},
+                {},
+                filterFields,
+                {},
+                {},
+                removeFunc
+            );
+            assert.deepStrictEqual(result, {
+                number_records: 5,
+                start_record: 0
+            });
+        });
+
+        it("should leave out imperfect filter strings not applicable to the searched value", () => {
+            const options = {
+                filter: "john",
+                limit: 5,
+                start: 0
+            };
+            const filterFields = {
+                friends: "in"
+            };
+            const removeFunc = {
+                friends: value => isNaN(parseInt(value))
+            };
+            const result = ripeCommons.filterToParams(
+                options,
+                {},
+                {},
+                filterFields,
+                {},
+                {},
+                removeFunc
             );
             assert.deepStrictEqual(result, {
                 number_records: 5,

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,8 +1,8 @@
 const assert = require("assert");
 const ripeCommons = require("..");
 
-describe("Filter", function () {
-    describe("#filterToParams()", function () {
+describe("Filter", function() {
+    describe("#filterToParams()", function() {
         it("should be able to build a filter string to filter only for id equal to 2", () => {
             const options = {
                 filter: "id=2",

--- a/test/time.js
+++ b/test/time.js
@@ -28,7 +28,7 @@ describe("Time", function() {
         });
 
         it("should format simple date strings and reverse the output", () => {
-            const result = ripeCommons.dateStringUTC(new Date("10/12/2020") / 1000, "-", {
+            const result = ripeCommons.dateStringUTC(new Date("10/12/2020Z") / 1000, "-", {
                 reverseDate: true
             });
             assert.deepStrictEqual(result, "2020-10-12");

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -15,6 +15,12 @@ export declare function filterToParams(
     nameFunc: Record<string, () => unknown>,
     filterFields: Record<string, string>,
     keywordFields: Record<string, string[]>,
-    { imperfectFilterFields, keywords }: {imperfectFilterFields: Record<string, string>, keywords: Record<string, () => unknown>} = {},
+    {
+        imperfectFilterFields,
+        keywords
+    }: {
+        imperfectFilterFields: Record<string, string>;
+        keywords: Record<string, () => unknown>;
+    } = {},
     removeFunc: Record<string, () => boolean>
 ): FilterParams;

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -14,5 +14,7 @@ export declare function filterToParams(
     nameAlias: Record<string, string>,
     nameFunc: Record<string, () => unknown>,
     filterFields: Record<string, string>,
-    keywordFields: Record<string, string[]>
+    keywordFields: Record<string, string[]>,
+    { imperfectFilterFields, keywords }: {imperfectFilterFields: Record<string, string>, keywords: Record<string, () => unknown>} = {},
+    removeFunc: Record<string, () => boolean>
 ): FilterParams;


### PR DESCRIPTION
### Issue
- https://github.com/ripe-tech/ripe-pulse/issues/436

### Decisions
- sometimes we may not want to apply a filter (e.g. orders:in:VALUE does not make sense to use if the value is not a number) and these conditional functions will add the filter or not based on the returned value
- specially important for filters that take only certain types of values and may error otherwise
